### PR TITLE
Fix synchronous error when invalid schema is specified.

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -118,9 +118,13 @@ api.validate = function(name, data, callback) {
   // do immediate validation if data is present
   if(arguments.length > 1) {
     if(notFound) {
-      return callback(new BedrockError(
+      var err = new BedrockError(
         'Could not validate data; unknown schema name (' + notFound + ').',
-        'UnknownSchema', {schema: notFound}));
+        'UnknownSchema', {schema: notFound});
+      if(typeof callback === 'function') {
+        return callback(err);
+      }
+      throw err;
     }
     // use schema.body (assume 3 parameter is called w/string)
     return api.validateInstance(data, schemas.body, callback);

--- a/tests/001-schemas.js
+++ b/tests/001-schemas.js
@@ -4,10 +4,35 @@
 
 'use strict';
 
+var expect = GLOBAL.chai.expect;
 var validation = require('../lib/validation');
+var validate = validation.validate;
 
 // FIXME: add more tests, test for proper errors
 describe('bedrock-validation', function() {
+  describe('invalid schema specified', function() {
+    describe('synchronous mode', function() {
+      it('should throw an error', function() {
+        expect(function() {
+          validate('test-unknown-schema', {some: 'object'});})
+          .to.throw(
+            'UnknownSchema: Could not validate data; unknown schema name ' +
+            '(test-unknown-schema).');
+      });
+    });
+    describe('asynchronous mode', function() {
+      it('should call callback with an error', function(done) {
+        validate('test-unknown-schema', {some: 'object'}, function(err) {
+          should.exist(err);
+          err.message.should.equal(
+            'Could not validate data; unknown schema name ' +
+            '(test-unknown-schema).');
+          done();
+        });
+      });
+    });
+  });
+
   describe('comment', function() {
     var schema = validation.getSchema('comment');
     it('should be an Object', function() {


### PR DESCRIPTION
When using the validate function synchronously,, no proper error was being thrown.