### PR TITLE
4.x - New Response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # bedrock-validation ChangeLog
 
+## 4.0.0 - TBD
+
+### Changed
+- Remove `async` module dependency.
+- Return value is {valid: <bool>, error: <error>}
+
 ## 3.1.2 - 2018-09-17
 
-## Fixed
+### Fixed
 - Invalid `jsonldType` schema.
 
 ## 3.1.1 - 2018-09-13

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install bedrock-validation
 
 ```js
 var bedrock = require('bedrock');
-var validate = require('bedrock-validation').validate;
+var {validate} = require('bedrock-validation');
 
 // load schemas from '/foo'
 bedrock.config.validation.schema.paths.push('/foo');
@@ -89,8 +89,14 @@ to validate data using a schema that wasn't necessarily registered via
 the configuration system. The `schema` must be a [JSON schema][] instance. The
 return value will contain the result of the validation. If a `callback` is
 given, it will be called once the validation operation completes. If an
-error occurred (including a validation error), it will be passed as the
-first parameter of the `callback`.
+error occurred it will be passed in the second parameter of the `callback`.
+The synchronous and callback return value are the same:
+```js
+{
+  valid: <boolean>,
+  error: <error> // only present when valid === false
+}
+```
 
 
 [bedrock]: https://github.com/digitalbazaar/bedrock

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,8 @@
 /*!
  * Copyright (c) 2012-2018 Digital Bazaar, Inc. All rights reserved.
  */
+'use strict';
+
 const {config} = require('bedrock');
 const path = require('path');
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -208,18 +208,28 @@ api.validateInstance = (instance, schema, callback) => {
   for(const error of ajv.errors) {
     // create custom error details
     const details = {
+      instance,
+      params: error.params,
       path: error.dataPath,
-      'public': true
+      public: true,
+      schemaPath: error.schemaPath,
     };
+    let title;
+    if(Array.isArray(error.schema)) {
+      [title] = error.schema;
+    }
+    title = title || error.parentSchema.title || '',
     details.schema = {
-      title: error.parentSchema.title || '',
-      description: error.parentSchema.description || ''
+      description: error.parentSchema.description || '',
+      title,
     };
     // include custom errors or use default
-    details.errors = error.parentSchema.errors || {
-      invalid: 'Invalid input.',
-      missing: 'Missing input.'
-    };
+    // FIXME: enable if ajv supports this parentSchema.errors property
+    // it appears that this is not the case
+    // details.errors = error.parentSchema.errors || {
+    //   invalid: 'Invalid input.',
+    //   missing: 'Missing input.'
+    // };
     if(error.data) {
       if(error.parentSchema.errors && 'mask' in error.parentSchema.errors) {
         const mask = error.parentSchema.errors.mask;

--- a/lib/index.js
+++ b/lib/index.js
@@ -145,15 +145,21 @@ api.validate = function(name, data, callback) {
     async.waterfall([
       callback => {
         if(schemas.query) {
-          return api.validateInstance(
+          const result = api.validateInstance(
             req.query, schemas.query, err => callback(err));
+          if(!result.valid) {
+            return callback(result.error);
+          }
         }
         callback();
       },
       callback => {
         if(schemas.body) {
-          return api.validateInstance(
+          const result = api.validateInstance(
             req.body, schemas.body, err => callback(err));
+          if(!result.valid) {
+            return callback(result.error);
+          }
         }
         callback();
       }
@@ -190,15 +196,12 @@ api.validateInstance = (instance, schema, callback) => {
   const valid = ajv.validate(schema, instance);
   if(valid) {
     if(callback) {
-      // TODO: harmonize the return values for sync/async.
-      return callback();
+      return callback(null, {valid});
     }
-    return {valid, errors: []};
+    return {valid};
   }
 
-  const result = {
-    valid: false,
-  };
+  const result = {valid: false};
 
   // create public error messages
   const errors = [];
@@ -240,8 +243,7 @@ api.validateInstance = (instance, schema, callback) => {
   const error = new BedrockError(
     msg, 'ValidationError', {'public': true, errors, httpStatusCode: 400});
   if(callback) {
-    callback(error);
-    return result;
+    return callback(null, {error, valid: false});
   }
   result.error = error;
   return result;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,8 @@
 /*!
  * Copyright (c) 2012-2018 Digital Bazaar, Inc. All rights reserved.
  */
-const async = require('async');
+'use strict';
+
 const fs = require('fs');
 const PATH = require('path');
 const bedrock = require('bedrock');
@@ -142,28 +143,16 @@ api.validate = function(name, data, callback) {
 
   // return validation middleware
   return (req, res, next) => {
-    async.waterfall([
-      callback => {
-        if(schemas.query) {
-          const result = api.validateInstance(
-            req.query, schemas.query, err => callback(err));
-          if(!result.valid) {
-            return callback(result.error);
-          }
-        }
-        callback();
-      },
-      callback => {
-        if(schemas.body) {
-          const result = api.validateInstance(
-            req.body, schemas.body, err => callback(err));
-          if(!result.valid) {
-            return callback(result.error);
-          }
-        }
-        callback();
-      }
-    ], next);
+    let result;
+    if(schemas.query) {
+      result = api.validateInstance(req.query, schemas.query);
+    } else if(schemas.body) {
+      result = api.validateInstance(req.body, schemas.body);
+    }
+    if(!result.valid) {
+      return next(result.error);
+    }
+    next();
   };
 };
 
@@ -252,9 +241,10 @@ api.validateInstance = (instance, schema, callback) => {
     'A validation error occured in an unnamed validator.';
   const error = new BedrockError(
     msg, 'ValidationError', {'public': true, errors, httpStatusCode: 400});
-  if(callback) {
-    return callback(null, {error, valid: false});
-  }
+
   result.error = error;
+  if(callback) {
+    return callback(null, result);
+  }
   return result;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -142,15 +142,19 @@ api.validate = function(name, data, callback) {
   }
 
   // return validation middleware
+  // both `query` and `body` may need to be validated
   return (req, res, next) => {
-    let result;
     if(schemas.query) {
-      result = api.validateInstance(req.query, schemas.query);
-    } else if(schemas.body) {
-      result = api.validateInstance(req.body, schemas.body);
+      const result = api.validateInstance(req.query, schemas.query);
+      if(!result.valid) {
+        return next(result.error);
+      }
     }
-    if(!result.valid) {
-      return next(result.error);
+    if(schemas.body) {
+      const result = api.validateInstance(req.body, schemas.body);
+      if(!result.valid) {
+        return next(result.error);
+      }
     }
     next();
   };

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-validation",
   "dependencies": {
-    "ajv": "^6.0.0",
-    "async": "^1.4.2"
+    "ajv": "^6.0.0"
   },
   "peerDependencies": {
     "bedrock": "^1.0.0"

--- a/schemas/jsonPatch.js
+++ b/schemas/jsonPatch.js
@@ -4,31 +4,26 @@
 const bedrock = require('bedrock');
 
 const schema = {
-  required: true,
   title: 'JSON Patch',
   type: 'array',
   minItems: 1,
   items: {
     type: 'object',
-    required: true,
+    required: ['op', 'path'],
     // FIXME: more strictly validate properties based on value of `op`
     properties: {
       op: {
         type: 'string',
-        required: true,
         enum: ['add', 'copy', 'move', 'remove', 'replace', 'test']
       },
       from: {
         type: 'string',
-        required: false
       },
       path: {
         type: 'string',
-        required: true
       },
       value: {
         //type: ['number', 'string', 'boolean', 'object', 'array'],
-        required: false
       }
     },
     additionalProperties: false

--- a/schemas/sequencedPatch.js
+++ b/schemas/sequencedPatch.js
@@ -5,19 +5,17 @@ const bedrock = require('bedrock');
 const jsonPatch = require('./jsonPatch');
 
 const schema = {
-  required: true,
+  required: ['patch', 'sequence', 'target'],
   title: 'Sequence-based JSON Patch',
   type: 'object',
   properties: {
     target: {
       type: 'string',
-      required: true
     },
     // FIXME: also support `frame` property later
     patch: jsonPatch(),
     sequence: {
       type: 'integer',
-      required: true,
       minimum: 0,
       maximum: Number.MAX_SAFE_INTEGER
     }

--- a/test/mocha/001-schemas.js
+++ b/test/mocha/001-schemas.js
@@ -52,7 +52,7 @@ describe('bedrock-validation', function() {
     });
     it('should accept valid comments', function() {
       const small = validation.validate('comment', '1');
-      small.errors.should.be.empty;
+      should.not.exist(small.error);
       small.valid.should.be.true;
       const tmp = '12345678901234567890123456789012345678901234567890';
       const max = schema.maxLength / tmp.length;
@@ -85,7 +85,7 @@ describe('bedrock-validation', function() {
     });
     it('should accept valid emails', function() {
       const small = validation.validate('email', 'a@b.io');
-      small.errors.should.be.empty;
+      should.not.exist(small.error);
       small.valid.should.be.true;
     });
     it('should accept normal non-letter symbols', function() {


### PR DESCRIPTION
- This implements a response of `{valid: <bool>, error: <error>}`
- Removes the `async` module dep.

@dlongley in updating usage of these APIs, I see that you have promisified what is otherwise a synchronous API.  Did you have some use case in mind for that?

The API is designed to accept and use a `callback`.  If callback is not specified, then it operates synchronously.