### PR TITLE
Correct minor typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-validation ChangeLog
 
+## 7.1.1 - 
+
+### Fixed
+- Errors now use the spelling `occurred` vs the typo `occured`.
+
 ## 7.1.0 - 2022-10-16
 
 ### Added

--- a/lib/index.js
+++ b/lib/index.js
@@ -241,8 +241,8 @@ function _createError({schema, instance}) {
   }
 
   const msg = schema.title ?
-    'A validation error occured in the \'' + schema.title + '\' validator.' :
-    'A validation error occured in an unnamed validator.';
+    'A validation error occurred in the \'' + schema.title + '\' validator.' :
+    'A validation error occurred in an unnamed validator.';
   const error = new BedrockError(
     msg, 'ValidationError', {public: true, errors, httpStatusCode: 400});
 


### PR DESCRIPTION
patch release: `occurred` vs `occured` in an error message.