### PR TITLE
Update dependencies and common code on top of typo fix.

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,12 +1,15 @@
 module.exports = {
   root: true,
-  parserOptions: {
-    // this is required for dynamic import()
-    ecmaVersion: 2020
-  },
   env: {
     node: true
   },
-  extends: ['digitalbazaar', 'digitalbazaar/jsdoc'],
-  ignorePatterns: ['node_modules/']
+  extends: [
+    'digitalbazaar',
+    'digitalbazaar/jsdoc',
+    'digitalbazaar/module'
+  ],
+  ignorePatterns: ['node_modules/'],
+  rules: {
+    'unicorn/prefer-node-protocol': 'error'
+  }
 };

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,11 +8,11 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
@@ -24,11 +24,11 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [18.x, 20.x, 22.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - run: |
@@ -45,11 +45,11 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - run: |
@@ -61,7 +61,8 @@ jobs:
         cd test
         npm run coverage-ci
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v4
       with:
         file: ./test/coverage/lcov.info
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 - Errors now use the spelling `occurred` vs the typo `occured`.
+  - **NOTE**: This typo is known to be present in many tests of error message
+    and will require similar typo fixes.
 
 ## 7.1.0 - 2022-10-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # bedrock-validation ChangeLog
 
-## 7.1.1 - 
+## 7.1.1 - 2024-11-xx
+
+### Changed
+- Test and support Node.js 18, 20, 22.
 
 ### Fixed
 - Errors now use the spelling `occurred` vs the typo `occured`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Changed
 - Test and support Node.js 18, 20, 22.
+- Update dependencies:
+  - `ajv@6.12.6`
+  - `klona@2.0.6`
+- Update dev dependencies.
+- Fix lint issues.
 
 ### Fixed
 - Errors now use the spelling `occurred` vs the typo `occured`.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Bedrock validation",
   "main": "./lib/index.js",
   "scripts": {
-    "lint": "eslint ."
+    "lint": "eslint --ext .cjs,.js ."
   },
   "repository": {
     "type": "git",
@@ -24,19 +24,19 @@
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-validation",
   "dependencies": {
-    "ajv": "^6.12.0",
-    "klona": "^2.0.5"
+    "ajv": "^6.12.6",
+    "klona": "^2.0.6"
   },
   "peerDependencies": {
-    "@bedrock/core": "^6.0.0"
+    "@bedrock/core": "^6.2.0"
   },
   "directories": {
     "lib": "./lib"
   },
   "devDependencies": {
-    "eslint": "^7.32.0",
-    "eslint-config-digitalbazaar": "^2.8.0",
-    "eslint-plugin-jsdoc": "^37.9.7",
-    "jsdoc-to-markdown": "^7.1.1"
+    "eslint": "^8.57.1",
+    "eslint-config-digitalbazaar": "^5.2.0",
+    "eslint-plugin-jsdoc": "^50.5.0",
+    "eslint-plugin-unicorn": "^56.0.0"
   }
 }

--- a/schemas/helpers/idOrObjectWithId.js
+++ b/schemas/helpers/idOrObjectWithId.js
@@ -2,8 +2,8 @@
  * Copyright (c) 2012-2022 Digital Bazaar, Inc. All rights reserved.
  */
 import {extend as _extend} from '../../lib/helpers.js';
-import {klona} from 'klona';
 import identifier from '../identifier.js';
+import {klona} from 'klona';
 
 const schema = {
   title: 'identifier or an object with an id',

--- a/schemas/verifiableCredential.js
+++ b/schemas/verifiableCredential.js
@@ -2,9 +2,9 @@
  * Copyright (c) 2012-2022 Digital Bazaar, Inc. All rights reserved.
  */
 import {extend as _extend} from '../lib/helpers.js';
-import proof from './proof.js';
 import idOrObjectWithId from './helpers/idOrObjectWithId.js';
 import {klona} from 'klona';
+import proof from './proof.js';
 import w3cDateTime from './w3cDateTime.js';
 
 // https://www.w3.org/TR/vc-data-model/

--- a/schemas/verifiablePresentation.js
+++ b/schemas/verifiablePresentation.js
@@ -1,11 +1,11 @@
 /*!
  * Copyright (c) 2012-2022 Digital Bazaar, Inc. All rights reserved.
  */
-import verifiableCredential from './verifiableCredential.js';
 import {extend as _extend} from '../lib/helpers.js';
-import proof from './proof.js';
 import idOrObjectWithId from './helpers/idOrObjectWithId.js';
 import {klona} from 'klona';
+import proof from './proof.js';
+import verifiableCredential from './verifiableCredential.js';
 
 const schema = {
   title: 'Verifiable Presentation',


### PR DESCRIPTION
- This adds some cleanup on top of the unreleased occured/occurred typo fix.
- Releasing the typo fix **will** cause failures for many known tests that checked that typo in error messages.  The fix is simple and can be done as package updates happen.